### PR TITLE
Emergency fix

### DIFF
--- a/src/main/java/bodrov/valentin/spbsut/controller/MainController.java
+++ b/src/main/java/bodrov/valentin/spbsut/controller/MainController.java
@@ -189,6 +189,7 @@ public class MainController {
         List<File> files = dragEvent.getDragboard().getFiles();
         Image img = new Image(new FileInputStream(files.get(0)));
         setImageToImageView(SwingFXUtils.fromFXImage(img, null));
+        setOriginalImage(img);
     }
 
     public void handleHotKeys(KeyEvent keyEvent) {
@@ -206,6 +207,7 @@ public class MainController {
             if (clipboard.hasImage()) {
                 Image image = clipboard.getImage();
                 setImageToImageView(SwingFXUtils.fromFXImage(image, null));
+                setOriginalImage(image);
             }
         }
         if (copyImageKeyCombination.match(keyEvent)) {


### PR DESCRIPTION
Fixed a critical bug with NullPointerException when a dropped pic or pic from clipboard tried to be processed